### PR TITLE
Fix abbrev file space check

### DIFF
--- a/src/veupath/redmine/client/orgs_utils.py
+++ b/src/veupath/redmine/client/orgs_utils.py
@@ -84,8 +84,8 @@ class OrgsUtils:
         abbrevs_list = []
         with open(abbrev_path, "r") as abbrev_file:
             for line in abbrev_file:
-                if re.match("\t| ", line):
-                    raise Exception("Abbreviation file contains spaces or columns")
+                if re.search("\t| ", line):
+                    raise ValueError("Abbreviation file contains spaces or columns")
                 abbrev = line.strip().lower()
                 abbrevs_list.append(abbrev)
         abbrevs = set(abbrevs_list)


### PR DESCRIPTION
The spaces to check for are anywhere on the line, so use re.search, not re.match