### PR TITLE
Check issues with the wrong tracker

### DIFF
--- a/src/veupath/redmine/client/checks/check_missed_issues.py
+++ b/src/veupath/redmine/client/checks/check_missed_issues.py
@@ -139,10 +139,10 @@ def main():
 
     if args.get_missed in ("assignee", "all"):
         if not args.user_id:
-            print("User id required for missed assignee")
-            return
-        issues = get_missed_assignee(redmine, args.user_id)
-        IssueUtils.print_issues(issues, "missed assignee")
+            print("User ID required for 'missed assignee'")
+        else:
+            issues = get_missed_assignee(redmine, args.user_id)
+            IssueUtils.print_issues(issues, "missed assignee")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Since the client we have already filters by project, this check is relatively easy and useful (there was one task in B67 missed because of the wrong tracker).